### PR TITLE
Remove merged.lef from klayout setup

### DIFF
--- a/ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyt
+++ b/ihp-sg13g2/libs.tech/klayout/tech/sg13g2.lyt
@@ -83,7 +83,7 @@
    <macro-resolution-mode>default</macro-resolution-mode>
    <separate-groups>false</separate-groups>
    <map-file/>
-   <lef-files>merged.lef</lef-files> 
+   <lef-files/> 
   </lefdef>
   <mebes>
    <invert>false</invert>


### PR DESCRIPTION
Removing reference to merged.lef which does not exist.

Fixes NA

- [x] Tests pass 
- [X] Appropriate changes to README are included in PR (NA)
